### PR TITLE
Add store action

### DIFF
--- a/lib/add_book/add_book_model.dart
+++ b/lib/add_book/add_book_model.dart
@@ -7,11 +7,11 @@ class AddBookModel extends ChangeNotifier {
   String? author;
 
   Future addBook() async {
-    if (title == null) {
+    if (title == null || title == '') {
       throw '本のタイトルが入力されていません。';
     }
 
-    if (author == null) {
+    if (author == null || author!.isEmpty) {
       throw '著者が入力されていません。';
     }
 

--- a/lib/add_book/add_book_model.dart
+++ b/lib/add_book/add_book_model.dart
@@ -1,0 +1,23 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import '../domain/book.dart';
+
+class AddBookModel extends ChangeNotifier {
+  String? title; // ? は null 許容
+  String? author;
+
+  Future addBook() async {
+    if (title == null) {
+      throw '本のタイトルが入力されていません。';
+    }
+
+    if (author == null) {
+      throw '著者が入力されていません。';
+    }
+
+    await FirebaseFirestore.instance.collection('books').add({
+      'title': title,
+      'author': author,
+    });
+  }
+}

--- a/lib/add_book/add_book_page.dart
+++ b/lib/add_book/add_book_page.dart
@@ -36,10 +36,26 @@ class AddBookPage extends StatelessWidget {
                   },
                 ),
                 ElevatedButton(
-                    onPressed: () {
-                      model.addBook();
-                    },
-                    child: Text('追加'))
+                  onPressed: () async {
+                    try {
+                      await model.addBook();
+                    } catch (e) {
+                      final snackBar = SnackBar(
+                        backgroundColor: Colors.red[200],
+                        content: const Text('本のタイトルが入力されていません。'),
+                        action: SnackBarAction(
+                          textColor: Colors.black,
+                          label: 'Undo',
+                          onPressed: () {
+                            // Some code to undo the change.
+                          },
+                        ),
+                      );
+                      ScaffoldMessenger.of(context).showSnackBar(snackBar);
+                    }
+                  },
+                  child: const Text('追加'),
+                )
               ],
             );
           }),

--- a/lib/add_book/add_book_page.dart
+++ b/lib/add_book/add_book_page.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:testing_app/add_book/add_book_model.dart';
+import 'package:testing_app/domain/book.dart';
+
+class AddBookPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider<AddBookModel>(
+      create: (_) => AddBookModel(),
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('本を追加'),
+        ),
+        body: Center(
+          child: Consumer<AddBookModel>(builder: (context, model, child) {
+            return Column(
+              children: [
+                TextField(
+                  decoration: const InputDecoration(
+                    hintText: '本のタイトル',
+                  ),
+                  onChanged: (text) {
+                    model.title = text;
+                  },
+                ),
+                const SizedBox(
+                  height: 8,
+                ),
+                TextField(
+                  decoration: const InputDecoration(
+                    hintText: '著者',
+                  ),
+                  onChanged: (text) {
+                    model.author = text;
+                  },
+                ),
+                ElevatedButton(
+                    onPressed: () {
+                      model.addBook();
+                    },
+                    child: Text('追加'))
+              ],
+            );
+          }),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/add_book/add_book_page.dart
+++ b/lib/add_book/add_book_page.dart
@@ -39,6 +39,7 @@ class AddBookPage extends StatelessWidget {
                   onPressed: () async {
                     try {
                       await model.addBook();
+                      Navigator.of(context).pop(true);
                     } catch (e) {
                       final snackBar = SnackBar(
                         backgroundColor: Colors.red[200],

--- a/lib/book_list/book_list_page.dart
+++ b/lib/book_list/book_list_page.dart
@@ -34,19 +34,32 @@ class BookList extends StatelessWidget {
             );
           }),
         ),
-        floatingActionButton: FloatingActionButton(
-          onPressed: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (context) => AddBookPage(),
-                fullscreenDialog: true,
-              ),
-            );
-          },
-          tooltip: 'increment',
-          child: Icon(Icons.add),
-        ),
+        floatingActionButton:
+            Consumer<BookListModel>(builder: (context, model, child) {
+          return FloatingActionButton(
+            onPressed: () async {
+              final bool? added = await Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => AddBookPage(),
+                  fullscreenDialog: true,
+                ),
+              );
+
+              if (added != null && added) {
+                final snackBar = SnackBar(
+                  backgroundColor: Colors.green[200],
+                  content: const Text('追加しました！'),
+                );
+                ScaffoldMessenger.of(context).showSnackBar(snackBar);
+              }
+
+              model.fetchBoookList();
+            },
+            tooltip: 'increment',
+            child: Icon(Icons.add),
+          );
+        }),
       ),
     );
   }

--- a/lib/book_list/book_list_page.dart
+++ b/lib/book_list/book_list_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:testing_app/add_book/add_book_page.dart';
 import 'package:testing_app/book_list/book_list_model.dart';
 import 'package:testing_app/domain/book.dart';
 
@@ -33,8 +34,16 @@ class BookList extends StatelessWidget {
             );
           }),
         ),
-        floatingActionButton: const FloatingActionButton(
-          onPressed: null,
+        floatingActionButton: FloatingActionButton(
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (context) => AddBookPage(),
+                fullscreenDialog: true,
+              ),
+            );
+          },
           tooltip: 'increment',
           child: Icon(Icons.add),
         ),

--- a/lib/second_page.dart
+++ b/lib/second_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:testing_app/first_page.dart';
 import 'package:testing_app/third_page.dart';
 
-import 'book_list/book_list.dart';
+import 'book_list/book_list_page.dart';
 
 class SecondPage extends StatelessWidget {
   SecondPage(this.name);


### PR DESCRIPTION
- ファイル名変更 [6e9db0b](https://github.com/y129may9th/testing_app/pull/4/commits/6e9db0b014e416ad963573ed227bccc9f62fe14b)
- Firestore add() の処理追加と入力フォーム作成 [707d6f0](https://github.com/y129may9th/testing_app/pull/4/commits/707d6f0434cb81f37d90b5e82efb72c3da54c2de)
  - cf. [入力フォームを作る｜Flutter基礎入門 by Flutter大学](https://zenn.dev/kboy/books/ca6a9c93fd23f3/viewer/14dfcb)
- エラーハンドリング [4020dfa](https://github.com/y129may9th/testing_app/pull/4/commits/4020dfae20abe0509f7a4a4da748bef19ee23d69)
  - フォームが空のまま追加した時、エラーを表示
- 本を追加した後に、本一覧ページに戻るようにした [d025e4b](https://github.com/y129may9th/testing_app/pull/4/commits/d025e4b93b71a6f5364fb204f9eb2a14650f466c)

## Async / await について
### Future クラス
- 非同期処理の返り値を表すクラス

### FutureBuilder Widget
>Widgetを組み上げるbuild関数は Future関数でないため、
この中でasync / awaitを使うことはできません。
ここで登場するのがFutureBuilder Widgetです。

[【Flutter】 FutureとStream の違いって何？ - 週刊Flutter大学](https://blog.flutteruniv.com/flutter-future-stream-difference/)
[非同期処理-Future (Asynchronous Programming: Futures)](https://www.cresc.co.jp/tech/java/Google_Dart2/language/asynchrony_futures/asynchrony_futures.html)
[【Dart】Futureクラスとasync/awaitの基本的な使い方](https://zenn.dev/iwaku/articles/2020-12-29-iwaku)

## 画面遷移
- [画面遷移(Navigator) | Flutter Doc JP](https://flutter.ctrnost.com/basic/routing/)
- [Navigate to a new screen and back | Flutter](https://docs.flutter.dev/cookbook/navigation/navigation-basics)

## キャプチャ
追加ページ | 追加後 | エラー
-- | -- | --
![Simulator Screen Shot - iPhone 11 - 2022-10-17 at 13 29 47](https://user-images.githubusercontent.com/44105111/196321729-0a662ce5-7afd-46f1-9e06-ee9ebae4acfb.png) | ![Simulator Screen Shot - iPhone 11 - 2022-10-17 at 13 29 41](https://user-images.githubusercontent.com/44105111/196321738-65fca77e-55ca-41dc-9fdd-b627695f7985.png) | ![Simulator Screen Shot - iPhone 11 - 2022-10-17 at 13 34 09](https://user-images.githubusercontent.com/44105111/196321747-e1a6e2ef-30ae-4e4a-9919-b08efbe8b066.png)
