### PR TITLE
Add sign-in and sign-up featrure

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3,14 +3,26 @@ PODS:
     - Firebase/Firestore (= 9.6.0)
     - firebase_core
     - Flutter
+  - Firebase/Auth (9.6.0):
+    - Firebase/CoreOnly
+    - FirebaseAuth (~> 9.6.0)
   - Firebase/CoreOnly (9.6.0):
     - FirebaseCore (= 9.6.0)
   - Firebase/Firestore (9.6.0):
     - Firebase/CoreOnly
     - FirebaseFirestore (~> 9.6.0)
+  - firebase_auth (3.11.2):
+    - Firebase/Auth (= 9.6.0)
+    - firebase_core
+    - Flutter
   - firebase_core (1.24.0):
     - Firebase/CoreOnly (= 9.6.0)
     - Flutter
+  - FirebaseAuth (9.6.0):
+    - FirebaseCore (~> 9.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
+    - GoogleUtilities/Environment (~> 7.7)
+    - GTMSessionFetcher/Core (< 3.0, >= 1.7)
   - FirebaseCore (9.6.0):
     - FirebaseCoreDiagnostics (~> 9.0)
     - FirebaseCoreInternal (~> 9.0)
@@ -36,11 +48,22 @@ PODS:
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
+  - GoogleUtilities/AppDelegateSwizzler (7.8.0):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Network
   - GoogleUtilities/Environment (7.8.0):
     - PromisesObjC (< 3.0, >= 1.2)
   - GoogleUtilities/Logger (7.8.0):
     - GoogleUtilities/Environment
+  - GoogleUtilities/Network (7.8.0):
+    - GoogleUtilities/Logger
+    - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Reachability
   - "GoogleUtilities/NSData+zlib (7.8.0)"
+  - GoogleUtilities/Reachability (7.8.0):
+    - GoogleUtilities/Logger
+  - GTMSessionFetcher/Core (2.1.0)
   - nanopb (2.30909.0):
     - nanopb/decode (= 2.30909.0)
     - nanopb/encode (= 2.30909.0)
@@ -50,6 +73,7 @@ PODS:
 
 DEPENDENCIES:
   - cloud_firestore (from `.symlinks/plugins/cloud_firestore/ios`)
+  - firebase_auth (from `.symlinks/plugins/firebase_auth/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - FirebaseFirestore (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `9.6.0`)
   - Flutter (from `Flutter`)
@@ -57,17 +81,21 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - Firebase
+    - FirebaseAuth
     - FirebaseCore
     - FirebaseCoreDiagnostics
     - FirebaseCoreInternal
     - GoogleDataTransport
     - GoogleUtilities
+    - GTMSessionFetcher
     - nanopb
     - PromisesObjC
 
 EXTERNAL SOURCES:
   cloud_firestore:
     :path: ".symlinks/plugins/cloud_firestore/ios"
+  firebase_auth:
+    :path: ".symlinks/plugins/firebase_auth/ios"
   firebase_core:
     :path: ".symlinks/plugins/firebase_core/ios"
   FirebaseFirestore:
@@ -84,7 +112,9 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   cloud_firestore: 49d69be2b924677f2974d8b38acc705c9908c09b
   Firebase: 5ae8b7cf8efce559a653aef0ad95bab3f427c351
+  firebase_auth: 07a4db69cfa447ac42cb7faa560fc100708b707c
   firebase_core: 7c28ecc1e5dd74e03829ac3e9ff5ba3314e737a9
+  FirebaseAuth: e4a5d3c36e778e41141b91cc861103a441d80bcc
   FirebaseCore: 2082fffcd855f95f883c0a1641133eb9bbe76d40
   FirebaseCoreDiagnostics: 99a495094b10a57eeb3ae8efa1665700ad0bdaa6
   FirebaseCoreInternal: bca76517fe1ed381e989f5e7d8abb0da8d85bed3
@@ -92,6 +122,7 @@ SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   GoogleDataTransport: 1c8145da7117bd68bbbed00cf304edb6a24de00f
   GoogleUtilities: 1d20a6ad97ef46f67bbdec158ce00563a671ebb7
+  GTMSessionFetcher: ffbb25ec00ebcb5201adab0a56d808f6f1902d9f
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
 

--- a/lib/book_list/book_list_page.dart
+++ b/lib/book_list/book_list_page.dart
@@ -5,6 +5,7 @@ import 'package:testing_app/add_book/add_book_page.dart';
 import 'package:testing_app/book_list/book_list_model.dart';
 import 'package:testing_app/domain/book.dart';
 import 'package:testing_app/edit_book/edit_book_page.dart';
+import 'package:testing_app/login/login_page.dart';
 import 'package:testing_app/main.dart';
 
 class BookList extends StatelessWidget {
@@ -15,6 +16,21 @@ class BookList extends StatelessWidget {
       child: Scaffold(
         appBar: AppBar(
           title: const Text('本一覧'),
+          actions: [
+            IconButton(
+              onPressed: () async {
+                //画面遷移
+                await Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => LoginPage(),
+                    fullscreenDialog: true,
+                  ),
+                );
+              },
+              icon: const Icon(Icons.person),
+            )
+          ],
         ),
         body: Center(
           child: Consumer<BookListModel>(
@@ -126,37 +142,33 @@ class BookList extends StatelessWidget {
           title: Text("削除の確認"),
           content: Text("『${book.title}』を削除しますか？"),
           actions: [
-            Builder(
-              builder: (context) {
-                return TextButton(
-                  child: Text("いいえ"),
-                  onPressed: () => Navigator.pop(context),
-                );
-              }
-            ),
-            Builder(
-              builder: (context) {
-                return TextButton(
-                  child: Text("はい"),
-                  onPressed: () async {
-                    await model.deleteBook(book);
-                    Navigator.pop(context);
+            Builder(builder: (context) {
+              return TextButton(
+                child: Text("いいえ"),
+                onPressed: () => Navigator.pop(context),
+              );
+            }),
+            Builder(builder: (context) {
+              return TextButton(
+                child: Text("はい"),
+                onPressed: () async {
+                  await model.deleteBook(book);
+                  Navigator.pop(context);
 
-                    ScaffoldMessengerState _scaffoldMessangerState =
-                        scaffoldKey.currentState!;
+                  ScaffoldMessengerState _scaffoldMessangerState =
+                      scaffoldKey.currentState!;
 
-                    _scaffoldMessangerState.showSnackBar(
-                      SnackBar(
-                        backgroundColor: Colors.red[300],
-                        content: Text("『${book.title}』を削除しました"),
-                      ),
-                    );
+                  _scaffoldMessangerState.showSnackBar(
+                    SnackBar(
+                      backgroundColor: Colors.red[300],
+                      content: Text("『${book.title}』を削除しました"),
+                    ),
+                  );
 
-                    model.fetchBookList();
-                  },
-                );
-              }
-            ),
+                  model.fetchBookList();
+                },
+              );
+            }),
           ],
         );
       },

--- a/lib/login/login_model.dart
+++ b/lib/login/login_model.dart
@@ -1,0 +1,25 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+class LoginModel extends ChangeNotifier {
+  final emailController = TextEditingController();
+  final passwordController = TextEditingController();
+
+  String? email;
+  String? password;
+
+  void setEmail(String email) {
+    this.email = email;
+    notifyListeners();
+  }
+
+  void setPassword(String password) {
+    this.password = password;
+    notifyListeners();
+  }
+
+  Future signIn() async {
+    this.email = emailController.text;
+    this.password = passwordController.text;
+  }
+}

--- a/lib/login/login_model.dart
+++ b/lib/login/login_model.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 
 class LoginModel extends ChangeNotifier {
@@ -7,6 +8,18 @@ class LoginModel extends ChangeNotifier {
 
   String? email;
   String? password;
+
+  bool isLoading = false;
+
+  void startLoading() {
+    isLoading = true;
+    notifyListeners();
+  }
+
+  void endLoading() {
+    isLoading = false;
+    notifyListeners();
+  }
 
   void setEmail(String email) {
     this.email = email;
@@ -18,8 +31,20 @@ class LoginModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future signIn() async {
+  Future login() async {
     this.email = emailController.text;
     this.password = passwordController.text;
+
+    if (email != null && password != null) {
+      await FirebaseAuth.instance.signInWithEmailAndPassword(
+        email: email!,
+        password: password!,
+      );
+
+      // 他の情報を追加するときに uid を使い回すとか
+      final currentUser = FirebaseAuth.instance.currentUser;
+      final uid = currentUser!.uid;
+      print(uid);
+    }
   }
 }

--- a/lib/login/login_page.dart
+++ b/lib/login/login_page.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:testing_app/login/login_model.dart';
+import 'package:testing_app/register/register_page.dart';
+
+class LoginPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider<LoginModel>(
+      create: (_) => LoginModel(),
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Login'),
+        ),
+        body: Center(
+          child: Consumer<LoginModel>(builder: (context, model, child) {
+            return Column(
+              children: [
+                TextField(
+                  controller: model.emailController,
+                  decoration: const InputDecoration(
+                    hintText: 'Email',
+                  ),
+                  onChanged: (text) {
+                    model.setPassword(text);
+                  },
+                ),
+                const SizedBox(
+                  height: 8,
+                ),
+                TextField(
+                  controller: model.passwordController,
+                  decoration: const InputDecoration(
+                    hintText: 'パスワード',
+                  ),
+                  onChanged: (text) {
+                    model.setEmail(text);
+                  },
+                ),
+                ElevatedButton(
+                  onPressed: () async {
+                    try {
+                      await model.signIn();
+                      // Navigator.of(context).pop(model.title);
+                    } catch (e) {
+                      final snackBar = SnackBar(
+                        backgroundColor: Colors.red[200],
+                        content: const Text(''),
+                        action: SnackBarAction(
+                          textColor: Colors.black,
+                          label: 'Undo',
+                          onPressed: () {
+                            // Some code to undo the change.
+                          },
+                        ),
+                      );
+                      ScaffoldMessenger.of(context).showSnackBar(snackBar);
+                    }
+                  },
+                  child: const Text('ログイン'),
+                ),
+                TextButton(
+                  onPressed: () async {
+                    await Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => RegisterPage(),
+                        fullscreenDialog: true,
+                      ),
+                    );
+                  },
+                  child: const Text('新規登録の方はこちら'),
+                ),
+              ],
+            );
+          }),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/login/login_page.dart
+++ b/lib/login/login_page.dart
@@ -14,63 +14,80 @@ class LoginPage extends StatelessWidget {
         ),
         body: Center(
           child: Consumer<LoginModel>(builder: (context, model, child) {
-            return Column(
+            return Stack(
               children: [
-                TextField(
-                  controller: model.emailController,
-                  decoration: const InputDecoration(
-                    hintText: 'Email',
-                  ),
-                  onChanged: (text) {
-                    model.setPassword(text);
-                  },
-                ),
-                const SizedBox(
-                  height: 8,
-                ),
-                TextField(
-                  controller: model.passwordController,
-                  decoration: const InputDecoration(
-                    hintText: 'パスワード',
-                  ),
-                  onChanged: (text) {
-                    model.setEmail(text);
-                  },
-                ),
-                ElevatedButton(
-                  onPressed: () async {
-                    try {
-                      await model.signIn();
-                      // Navigator.of(context).pop(model.title);
-                    } catch (e) {
-                      final snackBar = SnackBar(
-                        backgroundColor: Colors.red[200],
-                        content: const Text(''),
-                        action: SnackBarAction(
-                          textColor: Colors.black,
-                          label: 'Undo',
-                          onPressed: () {
-                            // Some code to undo the change.
-                          },
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Column(
+                    children: [
+                      TextField(
+                        controller: model.emailController,
+                        decoration: const InputDecoration(
+                          hintText: 'Email',
                         ),
-                      );
-                      ScaffoldMessenger.of(context).showSnackBar(snackBar);
-                    }
-                  },
-                  child: const Text('ログイン'),
-                ),
-                TextButton(
-                  onPressed: () async {
-                    await Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) => RegisterPage(),
-                        fullscreenDialog: true,
+                        onChanged: (text) {
+                          model.setPassword(text);
+                        },
                       ),
-                    );
-                  },
-                  child: const Text('新規登録の方はこちら'),
+                      const SizedBox(
+                        height: 8,
+                      ),
+                      TextField(
+                        controller: model.passwordController,
+                        decoration: const InputDecoration(
+                          hintText: 'パスワード',
+                        ),
+                        onChanged: (text) {
+                          model.setEmail(text);
+                        },
+                      ),
+                      ElevatedButton(
+                        onPressed: () async {
+                          model.startLoading();
+                          try {
+                            await model.login();
+                            Navigator.of(context).pop();
+                          } catch (e) {
+                            final snackBar = SnackBar(
+                              backgroundColor: Colors.red[200],
+                              content: Text(e.toString()),
+                              action: SnackBarAction(
+                                textColor: Colors.black,
+                                label: 'Undo',
+                                onPressed: () {
+                                  // Some code to undo the change.
+                                },
+                              ),
+                            );
+                            ScaffoldMessenger.of(context).showSnackBar(snackBar);
+                          } finally {
+                            model.endLoading();
+                          }
+                        },
+                        child: const Text('ログイン'),
+                      ),
+                      TextButton(
+                        onPressed: () async {
+                          await Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => RegisterPage(),
+                              fullscreenDialog: true,
+                            ),
+                          );
+                        },
+                        child: const Text('新規登録の方はこちら'),
+                      ),
+                    ],
+                  ),
                 ),
+                if (model.isLoading)
+                  Container(
+                    color: Colors.black54,
+                    child: const Center(
+                      child: CircularProgressIndicator(),
+                    ),
+                  )
               ],
             );
           }),

--- a/lib/register/register_model.dart
+++ b/lib/register/register_model.dart
@@ -1,13 +1,25 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 
 class RegisterModel extends ChangeNotifier {
-
   final emailController = TextEditingController();
   final passwordController = TextEditingController();
 
   String? email;
   String? password;
+
+  bool isLoading = false;
+
+  void startLoading() {
+    isLoading = true;
+    notifyListeners();
+  }
+
+    void endLoading() {
+    isLoading = false;
+    notifyListeners();
+  }
 
   void setEmail(String email) {
     this.email = email;
@@ -24,11 +36,25 @@ class RegisterModel extends ChangeNotifier {
     this.password = passwordController.text;
 
     // Firebase auth で認証のためのユーザー作成
+    if (email != null && password != null) {
+      final userCredential =
+          await FirebaseAuth.instance.createUserWithEmailAndPassword(
+        email: email!,
+        password: password!,
+      );
 
-    // Firestore にユーザのほか情報を保存
-    // await FirebaseFirestore.instance.collection('books').doc(book.id).update({
-    //   'title': title,
-    //   'author': author,
-    // });
+      final user = userCredential.user;
+      if (user != null) {
+        final uid = user.uid;
+
+        // Firestore にユーザのほか情報を保存
+        // データベースにワード入れない。Auth だけ知っていればいい。
+        final doc = FirebaseFirestore.instance.collection('users').doc(uid);
+        await doc.set({
+          'uid': uid,
+          'email': email,
+        });
+      }
+    }
   }
 }

--- a/lib/register/register_model.dart
+++ b/lib/register/register_model.dart
@@ -1,0 +1,34 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+class RegisterModel extends ChangeNotifier {
+
+  final emailController = TextEditingController();
+  final passwordController = TextEditingController();
+
+  String? email;
+  String? password;
+
+  void setEmail(String email) {
+    this.email = email;
+    notifyListeners();
+  }
+
+  void setPassword(String password) {
+    this.password = password;
+    notifyListeners();
+  }
+
+  Future signUp() async {
+    this.email = emailController.text;
+    this.password = passwordController.text;
+
+    // Firebase auth で認証のためのユーザー作成
+
+    // Firestore にユーザのほか情報を保存
+    // await FirebaseFirestore.instance.collection('books').doc(book.id).update({
+    //   'title': title,
+    //   'author': author,
+    // });
+  }
+}

--- a/lib/register/register_page.dart
+++ b/lib/register/register_page.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:testing_app/register/register_model.dart';
+
+class RegisterPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider<RegisterModel>(
+      create: (_) => RegisterModel(),
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Signup'),
+        ),
+        body: Center(
+          child: Consumer<RegisterModel>(builder: (context, model, child) {
+            return Column(
+              children: [
+                TextField(
+                  controller: model.emailController,
+                  decoration: const InputDecoration(
+                    hintText: 'Email',
+                  ),
+                  onChanged: (text) {
+                    model.setPassword(text);
+                  },
+                ),
+                const SizedBox(
+                  height: 8,
+                ),
+                TextField(
+                  controller: model.passwordController,
+                  decoration: const InputDecoration(
+                    hintText: 'パスワード',
+                  ),
+                  onChanged: (text) {
+                    model.setEmail(text);
+                  },
+                ),
+                ElevatedButton(
+                  onPressed: () async {
+                    try {
+                      await model.signUp();
+                      // Navigator.of(context).pop(model.title);
+                    } catch (e) {
+                      final snackBar = SnackBar(
+                        backgroundColor: Colors.red[200],
+                        content: const Text('本のタイトルが入力されていません。'),
+                        action: SnackBarAction(
+                          textColor: Colors.black,
+                          label: 'Undo',
+                          onPressed: () {
+                            // Some code to undo the change.
+                          },
+                        ),
+                      );
+                      ScaffoldMessenger.of(context).showSnackBar(snackBar);
+                    }
+                  },
+                  child: const Text('登録する'),
+                )
+              ],
+            );
+          }),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/register/register_page.dart
+++ b/lib/register/register_page.dart
@@ -13,51 +13,70 @@ class RegisterPage extends StatelessWidget {
         ),
         body: Center(
           child: Consumer<RegisterModel>(builder: (context, model, child) {
-            return Column(
+            return Stack(
               children: [
-                TextField(
-                  controller: model.emailController,
-                  decoration: const InputDecoration(
-                    hintText: 'Email',
-                  ),
-                  onChanged: (text) {
-                    model.setPassword(text);
-                  },
-                ),
-                const SizedBox(
-                  height: 8,
-                ),
-                TextField(
-                  controller: model.passwordController,
-                  decoration: const InputDecoration(
-                    hintText: 'パスワード',
-                  ),
-                  onChanged: (text) {
-                    model.setEmail(text);
-                  },
-                ),
-                ElevatedButton(
-                  onPressed: () async {
-                    try {
-                      await model.signUp();
-                      // Navigator.of(context).pop(model.title);
-                    } catch (e) {
-                      final snackBar = SnackBar(
-                        backgroundColor: Colors.red[200],
-                        content: const Text('本のタイトルが入力されていません。'),
-                        action: SnackBarAction(
-                          textColor: Colors.black,
-                          label: 'Undo',
-                          onPressed: () {
-                            // Some code to undo the change.
-                          },
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Column(
+                    children: [
+                      TextField(
+                        controller: model.emailController,
+                        decoration: const InputDecoration(
+                          hintText: 'Email',
                         ),
-                      );
-                      ScaffoldMessenger.of(context).showSnackBar(snackBar);
-                    }
-                  },
-                  child: const Text('登録する'),
-                )
+                        onChanged: (text) {
+                          model.setPassword(text);
+                        },
+                      ),
+                      const SizedBox(
+                        height: 8,
+                      ),
+                      TextField(
+                        controller: model.passwordController,
+                        decoration: const InputDecoration(
+                          hintText: 'パスワード',
+                        ),
+                        onChanged: (text) {
+                          model.setEmail(text);
+                        },
+                      ),
+                      ElevatedButton(
+                        onPressed: () async {
+                          model.startLoading();
+                          try {
+                            await model.signUp();
+                            Navigator.of(context).pop();
+                          } catch (e) {
+                            final snackBar = SnackBar(
+                              backgroundColor: Colors.red[200],
+                              content: Text(e.toString()),
+                              action: SnackBarAction(
+                                textColor: Colors.black,
+                                label: 'Undo',
+                                onPressed: () {
+                                  print(e);
+                                  // Some code to undo the change.
+                                },
+                              ),
+                            );
+                            ScaffoldMessenger.of(context)
+                                .showSnackBar(snackBar);
+                          } finally {
+                            model.endLoading();
+                          }
+                        },
+                        child: const Text('登録する'),
+                      )
+                    ],
+                  ),
+                ),
+                if (model.isLoading)
+                  Container(
+                    color: Colors.black54,
+                    child: const Center(
+                      child: CircularProgressIndicator(),
+                    ),
+                  )
               ],
             );
           }),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -78,6 +78,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.1"
+  firebase_auth:
+    dependency: "direct main"
+    description:
+      name: firebase_auth
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.11.2"
+  firebase_auth_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_auth_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.10.1"
+  firebase_auth_web:
+    dependency: transitive
+    description:
+      name: firebase_auth_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.6.1"
   firebase_core:
     dependency: "direct main"
     description:
@@ -128,6 +149,20 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.2"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.0"
   js:
     dependency: transitive
     description:
@@ -238,6 +273,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.12"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.1"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   cloud_firestore: ^3.5.1
   provider: ^6.0.4
   flutter_slidable: ^2.0.0
+  firebase_auth: ^3.11.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- ユーザー登録とログイン用の UI [fe2c108](https://github.com/y129may9th/testing_app/pull/7/commits/fe2c10800eda911fd9163f0574a0158ee3461fde)
- firebase auth を使って Sign-up 機能追加 [c01b054](https://github.com/y129may9th/testing_app/pull/7/commits/c01b054011d8bdc9dd07492049560a54a9213ed2)
- firebase auth を使って Login 機能追加 [9d0fe97](https://github.com/y129may9th/testing_app/pull/7/commits/9d0fe97c69a63e4870c57a6952ed2d41924029d0)

cf. [【2021年9月最新】Firebase Authで新規登録・ログインを実装しよう - YouTube](https://www.youtube.com/watch?v=sGaFkMynntU&list=PLuLRJz1UnJzEYLFd1ihJit1E6dYol8VC5&index=8)
